### PR TITLE
Set plugins.profiles.current according to profile_change

### DIFF
--- a/src/plugins/xupnpd_profiles.lua
+++ b/src/plugins/xupnpd_profiles.lua
@@ -33,7 +33,7 @@ local this = {
 		load_plugins(cfg.profiles or "./profiles/",'profile')
 	end,
 	http_handler = function(what,from,port,msg)
-		profile_change(msg['user-agent'], msg)
+		plugins.profiles.current = profile_change(msg['user-agent'], msg)
 	end,
 	sendurl = function(url,range) end,
 	ui_config_vars = {


### PR DESCRIPTION
Since changing the scope in [0811fd6], the local `profile_change` function isn't called anymore.
In order to properly set the current profile, the result of the global `profile_change` function must be set to (global) `plugins.profiles.current`.
