### PR TITLE
Client playback history plugin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,8 +5,8 @@ steps:
 - name: compile_and_test
   image: alpine:3.9		# 3.10 uses bash-5.0.x
   commands:
-    - apk add bash build-base coreutils curl git ncurses openssl-dev util-linux-dev # stdbuf in coreutils, tput in ncurses, uuid/uuid.h in util-linux-dev
-    - git clone -b test_name_in_before_and_after https://github.com/samunders-core/roundup.git
+    - apk add bash build-base coreutils curl git ncurses openssl-dev perl util-linux-dev # stdbuf in coreutils, tput in ncurses, uuid/uuid.h in util-linux-dev
+    - git clone -b function_as_test_plan https://github.com/samunders-core/roundup.git
     - cd roundup
     - ./configure
     - make

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ steps:
 - name: compile_and_test
   image: alpine:3.9		# 3.10 uses bash-5.0.x
   commands:
-    - apk add bash build-base coreutils curl git ncurses openssl-dev perl util-linux-dev # stdbuf in coreutils, tput in ncurses, uuid/uuid.h in util-linux-dev
+    - apk add bash build-base coreutils curl git ncurses openssl-dev perl-html-parser util-linux-dev # stdbuf in coreutils, tput in ncurses, uuid/uuid.h in util-linux-dev
     - git clone -b function_as_test_plan https://github.com/samunders-core/roundup.git
     - cd roundup
     - ./configure

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ steps:
 - name: compile_and_test
   image: alpine:3.9		# 3.10 uses bash-5.0.x
   commands:
-    - apk add bash build-base coreutils curl git ncurses openssl-dev perl-html-parser util-linux-dev # stdbuf in coreutils, tput in ncurses, uuid/uuid.h in util-linux-dev
+    - apk add bash build-base coreutils curl git ncurses openssl-dev perl perl-html-parser util-linux-dev # stdbuf in coreutils, tput in ncurses, uuid/uuid.h in util-linux-dev
     - git clone -b function_as_test_plan https://github.com/samunders-core/roundup.git
     - cd roundup
     - ./configure

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.[oa]
 *.sw[po]
-.idea/
-xupnpd
+.*
+xupnpd-*
 

--- a/src/plugins/xupnpd_recent.lua
+++ b/src/plugins/xupnpd_recent.lua
@@ -91,12 +91,12 @@ function recent_manage_symlinks(pls, recent) -- recent is NOT /-terminated
   recent_shell('F="$(readlink -f "$1")" && mv $4 "$F" "$F.moved" && find -L "$2" -maxdepth 1 -type l -exec rm $4 -f {} "+" ; ' ..
     'mv $4 "$F.moved" "$F" ; ln $4 -fs "$F" "$2/0-$3"', pls.path, recent, recent_unique_name(pls), cfg.debug>0 and "-v" or "") -- keep single existing link to pls.path
   local remaining = recent_count()
-  for name in recent_popen('find "$1" -type l -print0 | sort -z', recent) do
+  for name in recent_popen('find "$1" -type l -print0 | LC_ALL=C sort -z', recent) do
     recent_keep_only_remaining(remaining, name)
     remaining = remaining - 1
   end
   local index, width = 1, #("" .. recent_count()) + 1
-  for name in recent_popen('find "$1" -type l -print0 | sort -z', recent) do
+  for name in recent_popen('find "$1" -type l -print0 | LC_ALL=C sort -z', recent) do
     recent_rename_with(index, width, name)
     index = index + 1
   end

--- a/src/plugins/xupnpd_recent.lua
+++ b/src/plugins/xupnpd_recent.lua
@@ -1,0 +1,156 @@
+table.pack = table.pack or function(...) return { n = select("#", ...), ... } end  -- support Lua 5.1
+
+function recent_shell(cmd, ...)  -- space/apostrophe/ampersand-safe replacement of os.execute(cmd)
+  local args = table.pack(...)
+  local h = io.popen("xargs -t0n " .. (3 + args.n) .. " sh", 'w')
+  if h then
+    h:write("-c\0")
+    h:write(cmd .. "\0")
+    h:write("recent_shell\0") -- $0 for sh
+    for i = 1, args.n do
+      h:write(tostring(args[i] or "nil") .. "\0")
+    end
+    h:close()
+  end
+end
+
+function recent_unique_name(pls) -- do not assume globally-unique pls.name (S02E03 -> SerieName-S02-S02E03)
+  for i, t in ipairs(playlist) do
+    if pls.path:sub(1, #t[1]) == t[1] then
+      local name, count = pls.path:sub(#t[1] + 1):gsub("^[.]?/+" , "", 1):gsub("/+", "-")
+      return name
+    end
+  end
+  return pls.name .. "." .. pls.type
+end
+
+function recent_keep_only_remaining(count, bytes, stop, name)
+  if count <= 0 then
+    os.remove(name)
+  end
+  return bytes and bytes:sub(stop + 1)
+end
+
+function recent_keep_only(count, bytes, pipe)
+  local start, stop, name = string.find(bytes, "([^%z]*)%z")
+  if name then
+    return recent_keep_only_remaining(count, bytes, stop, name)
+  end
+  local more = pipe:read(1024)
+  if more then
+    bytes = bytes .. more
+  elseif bytes == "" then
+    return
+  end
+  local start, stop, name = string.find(bytes, "([^%z]*)%z")
+  return recent_keep_only_remaining(count, start and bytes, stop, name or bytes)
+end
+
+function recent_manage_symlinks(pls, recent) -- recent is NOT /-terminated
+  recent_shell('exec mkdir -p "$1"', recent)
+  recent_shell('exec mv -v "$1" "$1.moved"', pls.path) -- searching for broken links since busybox' find has no -lname switch
+  recent_shell('exec find -L "$1" -maxdepth 1 -type l -exec rm -vf {} "+"', recent)
+  recent_shell('exec mv -v "$1.moved" "$1"', pls.path)                                                              -- make next line create
+  recent_shell('exec ln -fsv "$(readlink -f "$1")" "$2/$(date +%s)-$3"', pls.path, recent, recent_unique_name(pls)) -- single existing link to pls.path
+  local pipe_path = os.tmpname() 
+  recent_shell('rm -f "$1" && mkfifo "$1"', pipe_path) -- rm since above creates file :-(
+  local pipe = io.popen('cat "'.. pipe_path .. '"', 'r') -- both io.open(pipe_path, 'r') & io.open(pipe_path, 'a') block
+  if pipe then
+    local task = coroutine.create(recent_shell) -- skip first N, remove rest until pipe is closed
+    if coroutine.resume(task, 'find "$1" -type l -print0 | sort -rz > "$2" ; rm -f "$2"', recent, pipe_path) then
+      local count = recent_count()
+      local bytes, remaining = "", count
+      while bytes do
+        bytes = recent_keep_only(remaining, bytes, pipe)
+        remaining = remaining - 1
+      end
+      count = #("" .. count) + 1 -- using minus separator as it sorts before any digit, zero-prefixed to make string sort same as number
+      recent_shell('find "$1" -type l | sort | cat -n | ( while read -r I P; do N="${P##*/}"; mv -nv "$P" "${P%/*}/$(printf "%0$2d" "$I")-${N#*-}" ; done )', recent, count)
+      pipe:close()
+    else
+      pipe:close()
+      os.remove(pipe_path)
+    end
+  end
+end
+
+function recent_playlist_exists(from)
+  for i, pls in ipairs(playlist) do
+    if #pls > 2 and pls[2] == plugins.recent.name and pls[3] == from then
+      return pls
+    end
+  end
+end
+
+function recent_path()  -- always /-terminated
+  return cfg.recent_path and #cfg.recent_path > 0 and string.gsub(cfg.recent_path, "([^/])$", "%1/", 1) or "./recent/"
+end
+
+function recent_count()
+  return cfg.recent_count and tonumber(cfg.recent_count) and tonumber(cfg.recent_count) > 0 and cfg.recent_count or 5
+end
+
+function recent_apply_config()
+  local dir = recent_path()
+  local sendevent = function(e) end
+  if cfg.recent_path_old and dir ~= cfg.recent_path_old then
+    recent_shell('exec mv -v "$1"* "$2"', cfg.recent_path_old, dir)
+    recent_shell('exec rmdir "$1"', cfg.recent_path_old)
+    sendevent = core.sendevent
+  end
+  cfg.recent_path_old = dir
+  for i, from in ipairs(dir and util.dir(dir) or {}) do
+    local recent = recent_playlist_exists(from)
+    if not recent then
+      recent = { dir .. from, plugins.recent.name, from }
+      playlist[#playlist + 1] = recent
+      sendevent = core.sendevent
+    elseif recent[1] ~= (dir .. from) then
+      recent[1] = dir .. from
+      sendevent = core.sendevent
+    end
+  end
+  sendevent("reload")
+end
+
+function recent_http_handler(what, from, port, msg)
+  from = string.match(from,'^[.%d]+')
+  local f = util.geturlinfo(cfg.www_root, msg.reqline[2])
+  if f and f.url then
+    local url, object = http_get_action(f.url)
+    local pls = url == "stream" and find_playlist_object(object)
+    if pls and pls.path then
+      local recent = recent_playlist_exists(from)
+      local dir = recent_path() .. from
+      if not recent then
+        recent = { dir, plugins.recent.name, from }
+        playlist[#playlist + 1] = recent
+      elseif recent[1] ~= dir then
+        recent[1] = dir
+      end
+      recent_manage_symlinks(pls, recent[1])
+      core.sendevent("reload")  -- symlink changes are reason why this is invoked unconditionally
+    end
+  end
+end
+
+plugins['recent']={}
+plugins.recent.disabled=false
+plugins.recent.name="Recent"
+plugins.recent.desc="enables per-host viewing history"
+plugins.recent.apply_config=recent_apply_config
+plugins.recent.http_handler=recent_http_handler
+plugins.recent.sendurl=function() end
+
+plugins.recent.ui_config_vars=
+{
+    { "input",  "recent_path" },
+    { "input",  "recent_count", "int" }
+}
+
+plugins.recent.ui_actions=
+{
+    recent_ui={ 'xupnpd - recent ui action', function() end }       -- 'http://127.0.0.1:4044/ui/recent_ui' for call
+}
+
+plugins.recent.ui_vars={}                                             -- use whatever ${key} in UI HTML templates

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -21,5 +21,5 @@ clean:
 .cpp.o:
 	PATH=$(PATH):$(LIBEXEC) STAGING_DIR=$(STAGING_DIR) $(CPP) -c $(CFLAGS) -o $@ $<
 
-test: all
-	cd ../test; PLATFORM=$(PLATFORM) roundup plugins/*-test.sh	# https://github.com/samunders-core/roundup/tree/test_name_in_before_and_after
+test: all	# either 'make test' or 'make test test=plugins/recent.lua-test.sh/it_symlinks_media_most_recent_first'
+	cd ../test; PLATFORM=$(PLATFORM) roundup $(or ${test},${test},plugins/*-test.sh)	# https://github.com/samunders-core/roundup/tree/function_as_test_plan

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -20,3 +20,6 @@ clean:
 
 .cpp.o:
 	PATH=$(PATH):$(LIBEXEC) STAGING_DIR=$(STAGING_DIR) $(CPP) -c $(CFLAGS) -o $@ $<
+
+test: all
+	cd ../test; PLATFORM=$(PLATFORM) roundup plugins/*-test.sh	# https://github.com/samunders-core/roundup/tree/test_name_in_before_and_after

--- a/src/xupnpd.lua
+++ b/src/xupnpd.lua
@@ -119,5 +119,7 @@ cfg.playlists_path='./playlists/'
 cfg.ui_path='./ui/'
 cfg.drive=''                    -- reload playlists only if drive state=active/idle, example: cfg.drive='/dev/sda'
 cfg.profiles='./profiles/'      -- device profiles feature
+cfg.recent_path='./recent/'   -- client history feature
+cfg.recent_count=5
 
 dofile('xupnpd_main.lua')

--- a/src/xupnpd_main.lua
+++ b/src/xupnpd_main.lua
@@ -2,6 +2,8 @@
 -- clark15b@gmail.com
 -- https://tsdemuxer.googlecode.com/svn/trunk/xupnpd
 
+table.maxn = table.maxn or function(t) return #t end  -- support Lua 5.3+
+
 http.sendurl_buffer_size(32768,1);
 
 if cfg.daemon==true then core.detach() end

--- a/src/xupnpd_main.lua
+++ b/src/xupnpd_main.lua
@@ -293,6 +293,18 @@ end
 -- event handlers
 events['SIGUSR1']=reload_playlist
 events['reload']=reload_playlist
+events['update_playlist']=function(new_path, ...)
+  local pls = {...}
+  for i, t in ipairs(playlist) do
+    if table.concat(t) == table.concat(pls) then
+      t[1] = new_path
+      reload_playlist()
+      return
+    end 
+  end
+  table.insert(playlist, pls)
+  reload_playlist()
+end 
 events['store']=cache_store
 events['sys_gc']=sys_gc
 events['subscribe']=subscribe

--- a/test/plugins/profiles.lua-test.sh
+++ b/test/plugins/profiles.lua-test.sh
@@ -12,7 +12,7 @@ before() {
 }
 
 xupnpd() {	# unbuffered IO eases failing test debugging
-  stdbuf -i 0 -o 0 -e 0 "$SRC_DIR/xupnpd" "$@"
+  stdbuf -i 0 -o 0 -e 0 "$SRC_DIR/xupnpd"${PLATFORM:+-$PLATFORM} "$@"
 }
 
 lookup() {	# regex; like grep, but prints first match on success, everything when failed

--- a/test/plugins/recent.lua-test.sh
+++ b/test/plugins/recent.lua-test.sh
@@ -225,3 +225,16 @@ it_handles_shell_metachars_correctly() {
     seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t rm -f
   done
 }
+
+it_updates_item_position_when_played_again() {
+  it_preserves_5_symlinks_by_default
+
+  http stream/0_2_2.avi
+
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_4.avi ]
+  [ -L recent/127.0.0.1/03-0_1_5.avi ]
+  [ -L recent/127.0.0.1/04-0_1_6.avi ]
+  [ -L recent/127.0.0.1/05-0_1_3.avi ]
+}

--- a/test/plugins/recent.lua-test.sh
+++ b/test/plugins/recent.lua-test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env roundup
+
+before() {
+  export SRC_DIR="$(pwd)/../src"
+  export XUPNPDROOTDIR=`mktemp -d -t "${1:-tmp}.XXXXXX"`
+  pushd "$XUPNPDROOTDIR"
+  mkdir localmedia plugins recent
+  cp -r "$SRC_DIR/config" .
+  cp "$SRC_DIR/plugins/xupnpd_$(basename ${BASH_SOURCE%-test.sh})" plugins		# luckily roundup also assumes bash
+  cp "$SRC_DIR"/*.lua .
+  sed -i -re 's^--(.*[.]/localmedia.*)^\1^' -e "s/UPnP-IPTV/$(basename ${XUPNPDROOTDIR%.*})/" -e 's/(sort_files=).*/\1true/' xupnpd.lua
+}
+
+xupnpd() {	# unbuffered IO eases failing test debugging
+  stdbuf -i 0 -o 0 -e 0 "$SRC_DIR/xupnpd"${PLATFORM:+-$PLATFORM} "$@"
+}
+
+lookup() {	# regex; like grep, but prints first match on success, everything when failed
+  awk -v "PATT=$*" '$0 ~ PATT {found=1;lines=$0;exit} lines {lines=lines""RS""$0;next} {lines=$0} END {printf(lines);exit(1-found)}'
+}
+
+http() {	# /url_path?query [curl args]
+  URL="$1" && shift
+  curl --silent -4 --retry 5 --retry-connrefused --retry-delay 1 "$@" "http://localhost:4044/${URL#/}"
+}
+
+after() {
+  pkill xupnpd || true		# $! is empty :-(; true prevents failure on synchronous tests
+  TMP_DIR=`dirs +0`
+  popd
+  rm -r "$TMP_DIR"
+}
+
+it_loads_plugin_at_startup() {
+  PLUGIN_NAME="recent"
+  sed -i -re 's/core[.]mainloop[(][)]/print("'"$PLUGIN_NAME"' plugin type: " .. type(plugins["'"$PLUGIN_NAME"'"]))/' xupnpd_main.lua		# make our life easier by synchronous execution
+  
+  xupnpd | lookup "$PLUGIN_NAME plugin type: table"
+}
+
+it_symlinks_requested_stream() {
+  touch localmedia/0_1_1.avi
+
+  xupnpd &
+  
+  http stream/0_1_1.avi
+  [ -L recent/127.0.0.1/01-0_1_1.avi ]
+}
+
+it_preserves_5_symlinks_by_default() {
+  seq -f "localmedia/0_1_%1.0f.avi" 1 6 | xargs -t touch
+
+  xupnpd &
+  
+  for i in $(seq 1 6); do
+    http stream/0_1_$i.avi
+  done
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+  [ -L recent/127.0.0.1/03-0_1_4.avi ]
+  [ -L recent/127.0.0.1/04-0_1_5.avi ]
+  [ -L recent/127.0.0.1/05-0_1_6.avi ]
+}
+
+it_uses_configurable_count() {
+  touch localmedia/0_1_1.avi
+  touch localmedia/0_1_2.avi
+  touch localmedia/0_1_3.avi
+  sed -i -re "/^cfg[.]recent_count\s*=\s*/ s|[0-9]+|2|" xupnpd.lua
+
+  xupnpd &
+  
+  http stream/0_1_1.avi
+  http stream/0_1_2.avi
+  http stream/0_1_3.avi
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+}
+
+it_uses_configurable_path_with_optional_terminal_slash() {
+  touch localmedia/0_1_1.avi
+  touch localmedia/0_1_2.avi
+  mkdir -p custom_recent_dir/127.0.0.1
+  ln -s "$(readlink -f localmedia/0_1_1.avi)" custom_recent_dir/127.0.0.1/01-0_1_1.avi
+  sed -i -re "s|^(cfg[.]recent_path\s*=\s*')[^']*('.*)|\1./custom_recent_dir\2|" xupnpd.lua
+  
+  xupnpd &
+  
+  http stream/0_1_2.avi
+  [ -L custom_recent_dir/127.0.0.1/01-0_1_1.avi ]
+  [ -L custom_recent_dir/127.0.0.1/02-0_1_2.avi ]
+}
+
+it_uses_ui_entered_path() {
+  cp -R "$SRC_DIR/ui" .
+  touch localmedia/0_1_1.avi
+  touch localmedia/0_1_2.avi
+  touch localmedia/0_1_3.avi
+  mkdir recent/127.0.0.1 custom_recent_dir
+  ln -s "$(readlink -f localmedia/0_1_2.avi)" recent/127.0.0.1/01-0_1_2.avi
+  
+  xupnpd &
+  
+  http stream/0_1_1.avi
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_1.avi ]
+  [ -z "$(ls -A custom_recent_dir)" ]
+
+  cat <<BODY | tr '\n' '&' | http ui/apply --data-binary '@-'
+vk_private_workaround=true
+vk_video_count=100
+youtube_fmt=37
+youtube_region=*
+youtube_video_count=100
+vimeo_fmt=hd
+vimeo_video_count=100
+ivi_fmt=MP4-hi
+ivi_video_count=100
+ag_fmt=400p
+gametrailers_video_count=100
+recent_path=.%2Fcustom_recent_dir%2F
+name=UPnP-IPTV
+uuid=60bd2fb3-dabe-cb14-c766-0e319b54c29a
+default_mime_type=mpeg
+ssdp_interface=lo
+ssdp_notify_interval=15
+ssdp_max_age=1800
+http_port=4044
+user_agent=Mozilla%2F5.0
+http_timeout=30
+mcast_interface=eth1
+proxy=2
+dlna_notify=true
+dlna_subscribe_ttl=1800
+group=true
+sort_files=true
+feeds_update_interval=0
+playlists_update_interval=0
+drive=
+BODY
+
+  http stream/0_1_3.avi
+  [ -L custom_recent_dir/127.0.0.1/01-0_1_2.avi ]
+  [ -L custom_recent_dir/127.0.0.1/02-0_1_1.avi ]
+  [ -L custom_recent_dir/127.0.0.1/03-0_1_3.avi ]
+  [ ! -e recent ]
+}
+
+it_uses_ui_entered_count() {
+  cp -R "$SRC_DIR/ui" .
+  seq -f "localmedia/0_1_%1.0f.avi" 1 6 | xargs -t touch
+  sed -i -re "/^cfg[.]recent_count\s*=\s*/ s|[0-9]+|2|" xupnpd.lua
+  
+  xupnpd &
+  
+  http stream/0_1_1.avi
+  http stream/0_1_2.avi
+  http stream/0_1_3.avi
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+
+  cat <<BODY | tr '\n' '&' | http ui/apply --data-binary '@-'
+vk_private_workaround=true
+vk_video_count=100
+youtube_fmt=37
+youtube_region=*
+youtube_video_count=100
+vimeo_fmt=hd
+vimeo_video_count=100
+ivi_fmt=MP4-hi
+ivi_video_count=100
+ag_fmt=400p
+gametrailers_video_count=100
+recent_count=3
+name=UPnP-IPTV
+uuid=60bd2fb3-dabe-cb14-c766-0e319b54c29a
+default_mime_type=mpeg
+ssdp_interface=lo
+ssdp_notify_interval=15
+ssdp_max_age=1800
+http_port=4044
+user_agent=Mozilla%2F5.0
+http_timeout=30
+mcast_interface=eth1
+proxy=2
+dlna_notify=true
+dlna_subscribe_ttl=1800
+group=true
+sort_files=true
+feeds_update_interval=0
+playlists_update_interval=0
+drive=
+BODY
+
+  http stream/0_1_3.avi
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+
+  http stream/0_1_4.avi
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/01-0_1_2.avi ]
+  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+  [ -L recent/127.0.0.1/03-0_1_4.avi ]
+}
+
+it_handles_shell_metachars_correctly() {
+  sed -i -re "/^cfg[.]recent_count\s*=\s*/ s|[0-9]+|2|" xupnpd.lua
+  for SPECIAL in "'" '"' '`' '$' '&' '|' ';' ':' '\\' '*' '!' '+' '#' '(' ')' '{' '}' '[' ']' '<' '>'; do
+    seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t touch
+    
+    pgrep xupnpd || xupnpd &
+    
+    for i in $(seq 1 3); do
+      http "stream/0_1_$i.avi"
+    done
+    
+    [ ! -e "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ] && [ ! -L "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ]
+    [ -L "recent/127.0.0.1/01-0${SPECIAL}1_2.avi" ]
+    [ -L "recent/127.0.0.1/02-0${SPECIAL}1_3.avi" ]
+    
+    seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t rm -f
+  done
+}

--- a/test/plugins/recent.lua-test.sh
+++ b/test/plugins/recent.lua-test.sh
@@ -21,7 +21,7 @@ lookup() {	# [-F] [-A n] regex; like grep, but prints first match on success, ev
   [ "$1" = "-FA" ] && REGEX=0 && AFTER=$2 && shift && shift
   [ "$REGEX" -eq 1 -a "$1" = "-F" ] && REGEX=0 && shift
   [ "$AFTER" -eq 0 -a "$1" = "-A" ] && AFTER=$2 && shift && shift 
-  awk -v "AFTER=$AFTER" -v "REGEX=$REGEX" -v "PATT=$*" '
+  awk -v "AFTER=$AFTER" -v "REGEX=$REGEX" -v "PATT=${*/\\/\\\\}" '
     REGEX == 1 && $0 ~ PATT {found=1;lines=$0;if(AFTER==0)exit;next}
     REGEX == 0 && index($0, PATT) {found=1;lines=$0;if(AFTER==0)exit;next}
     lines {lines=lines""RS""$0;if(found&&--AFTER==0)exit;next}
@@ -290,8 +290,10 @@ it_handles_shell_metachars_correctly() {
     done
     
     [ ! -e "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ] && [ ! -L "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ] # lookup -F '...' has trouble with backslash
-    [ -L "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" ] && ls -l "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" | grep -F "$(pwd)/localmedia/0${SPECIAL}1_2.avi"
-    [ -L "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" ] && ls -l "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" | grep -F "$(pwd)/localmedia/0${SPECIAL}1_3.avi"
+    [ "$SPECIAL" = $'\n' ] || ls -l "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" | lookup -F "$(pwd)/localmedia/0${SPECIAL}1_2.avi"
+    [ "$SPECIAL" = $'\n' ] || ls -l "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" | lookup -F "$(pwd)/localmedia/0${SPECIAL}1_3.avi"
+    [ ! "$SPECIAL" = $'\n' ] || ls -l "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" | grep -FA 1 "$(pwd)/localmedia/0" | grep -F '1_2.avi'
+    [ ! "$SPECIAL" = $'\n' ] || ls -l "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" | grep -FA 1 "$(pwd)/localmedia/0" | grep -F '1_3.avi'
     
     rm -f "localmedia/0${SPECIAL}1_1.avi" "localmedia/0${SPECIAL}1_2.avi" "localmedia/0${SPECIAL}1_3.avi"
     rm -vf "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" "recent/127.0.0.1/02-0${SPECIAL}1_2.avi"

--- a/test/plugins/recent.lua-test.sh
+++ b/test/plugins/recent.lua-test.sh
@@ -8,20 +8,55 @@ before() {
   cp -r "$SRC_DIR/config" .
   cp "$SRC_DIR/plugins/xupnpd_$(basename ${BASH_SOURCE%-test.sh})" plugins		# luckily roundup also assumes bash
   cp "$SRC_DIR"/*.lua .
-  sed -i -re 's^--(.*[.]/localmedia.*)^\1^' -e "s/UPnP-IPTV/$(basename ${XUPNPDROOTDIR%.*})/" -e 's/(sort_files=).*/\1true/' xupnpd.lua
+  sed -i -re 's^--(.*Local Media Files.*)^\1^' -e "s/UPnP-IPTV/$(basename ${XUPNPDROOTDIR%.*})/" xupnpd.lua
 }
 
 xupnpd() {	# unbuffered IO eases failing test debugging
   stdbuf -i 0 -o 0 -e 0 "$SRC_DIR/xupnpd"${PLATFORM:+-$PLATFORM} "$@"
 }
 
-lookup() {	# regex; like grep, but prints first match on success, everything when failed
-  awk -v "PATT=$*" '$0 ~ PATT {found=1;lines=$0;exit} lines {lines=lines""RS""$0;next} {lines=$0} END {printf(lines);exit(1-found)}'
+lookup() {	# [-F] [-A n] regex; like grep, but prints first match on success, everything when failed
+  AFTER=0
+  REGEX=1
+  [ "$1" = "-FA" ] && REGEX=0 && AFTER=$2 && shift && shift
+  [ "$REGEX" -eq 1 -a "$1" = "-F" ] && REGEX=0 && shift
+  [ "$AFTER" -eq 0 -a "$1" = "-A" ] && AFTER=$2 && shift && shift 
+  awk -v "AFTER=$AFTER" -v "REGEX=$REGEX" -v "PATT=$*" '
+    REGEX == 1 && $0 ~ PATT {found=1;lines=$0;if(AFTER==0)exit;next}
+    REGEX == 0 && index($0, PATT) {found=1;lines=$0;if(AFTER==0)exit;next}
+    lines {lines=lines""RS""$0;if(found&&--AFTER==0)exit;next}
+    {lines=$0}
+    END {printf(lines);exit(1-found)}
+  '
 }
 
 http() {	# /url_path?query [curl args]
   URL="$1" && shift
-  curl --silent -4 --retry 5 --retry-connrefused --retry-delay 1 "$@" "http://localhost:4044/${URL#/}"
+  curl --silent -4 --retry 5 --retry-connrefused --retry-delay 1 "$@" --include "http://localhost:4044/${URL#/}"
+}
+
+browse() {	# objid
+  cat <<XML | http soap/cds --data-binary '@-' --header 'Content-Type: text/xml; charset="utf-8"' --header "SOAPAction: urn:schemas-upnp-org:service:ContentDirectory:1#Browse"
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body><u:Browse xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1">
+<ObjectID>$1</ObjectID>
+<BrowseFlag>BrowseDirectChildren</BrowseFlag>
+<Filter>*</Filter>
+<StartingIndex>0</StartingIndex>
+<RequestedCount>5000</RequestedCount>
+<SortCriteria></SortCriteria>
+</u:Browse>
+</s:Body>
+</s:Envelope>
+XML
+}
+
+in_tag() {
+  awk "-F(</?$1[^>]*>)+" '{for(i=2;i<NF;i=i+1) print $i}'
+}
+
+in_DIDL_lite() {
+  in_tag Result | perl -MHTML::Entities -pe 'decode_entities($_);' | in_tag DIDL-Lite
 }
 
 after() {
@@ -38,13 +73,33 @@ it_loads_plugin_at_startup() {
   xupnpd | lookup "$PLUGIN_NAME plugin type: table"
 }
 
-it_symlinks_requested_stream() {
-  touch localmedia/0_1_1.avi
+it_forces_sort_files() {
+  touch localmedia/second.avi
+  touch localmedia/first.mp4
+  touch localmedia/terminal.avi
+  touch localmedia/second_last.mkv
+  
+  xupnpd &
+  
+  browse 0 | in_DIDL_lite | lookup '<container id="0_1" childCount="4" parentID="0" restricted="true"><dc:title>Local Media Files</dc:title><upnp:class>object.container</upnp:class></container>'
+  browse 0_1 | in_DIDL_lite | in_tag item | \
+    lookup -FA 3 '<dc:title>first</dc:title><upnp:class>object.item.videoItem</upnp:class><res size="0" protocolInfo="http-get:*:video/mp4:*">http://127.0.0.1:4044/stream/0_1_1.mp4</res>' | \
+    lookup -FA 2 '<dc:title>second</dc:title><upnp:class>object.item.videoItem</upnp:class><res size="0" protocolInfo="http-get:*:video/avi:DLNA.ORG_PN=PV_DIVX_DX50;DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000">http://127.0.0.1:4044/stream/0_1_2.avi</res>' | \
+    lookup -FA 1 '<dc:title>second_last</dc:title><upnp:class>object.item.videoItem</upnp:class><res size="0" protocolInfo="http-get:*:video/x-matroska:*">http://127.0.0.1:4044/stream/0_1_3.mkv</res>' | \
+    lookup -FA 0 '<dc:title>terminal</dc:title><upnp:class>object.item.videoItem</upnp:class><res size="0" protocolInfo="http-get:*:video/avi:DLNA.ORG_PN=PV_DIVX_DX50;DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000">http://127.0.0.1:4044/stream/0_1_4.avi</res>'
+}
+
+it_symlinks_media_most_recent_first() {
+  touch localmedia/0_1_1.avi localmedia/0_1_2.avi
 
   xupnpd &
   
-  http stream/0_1_1.avi
-  [ -L recent/127.0.0.1/01-0_1_1.avi ]
+  http stream/0_1_1.avi | lookup 'HTTP/1.1 200 OK'
+  [ -L recent/127.0.0.1/01-0_1_1.avi ] && ls -l recent/127.0.0.1/01-0_1_1.avi | lookup '^.*localmedia/0_1_1[.]avi$'
+
+  http stream/0_1_2.avi | lookup 'HTTP/1.1 200 OK'
+  [ -L recent/127.0.0.1/01-0_1_2.avi ] && ls -l recent/127.0.0.1/01-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/02-0_1_1.avi ] && ls -l recent/127.0.0.1/02-0_1_1.avi | lookup '^.*localmedia/0_1_1[.]avi$'
 }
 
 it_preserves_5_symlinks_by_default() {
@@ -53,14 +108,25 @@ it_preserves_5_symlinks_by_default() {
   xupnpd &
   
   for i in $(seq 1 6); do
-    http stream/0_1_$i.avi
+    http stream/0_1_$i.avi | lookup 'HTTP/1.1 200 OK'
   done
   [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_3.avi ]
-  [ -L recent/127.0.0.1/03-0_1_4.avi ]
-  [ -L recent/127.0.0.1/04-0_1_5.avi ]
-  [ -L recent/127.0.0.1/05-0_1_6.avi ]
+  for i in $(seq 2 6); do
+    [ -L "recent/127.0.0.1/0$((7-$i))-0_1_$i.avi" ] && ls -l "recent/127.0.0.1/0$((7-$i))-0_1_$i.avi" | lookup "^.*localmedia/0_1_$i"'[.]avi$'
+  done
+}
+
+it_updates_item_position_when_played_again() {
+  it_preserves_5_symlinks_by_default
+
+  http stream/0_2_4.avi | lookup 'HTTP/1.1 200 OK'
+
+  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
+  [ -L recent/127.0.0.1/05-0_1_2.avi ] && ls -l recent/127.0.0.1/05-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/04-0_1_4.avi ] && ls -l recent/127.0.0.1/04-0_1_4.avi | lookup '^.*localmedia/0_1_4[.]avi$'
+  [ -L recent/127.0.0.1/03-0_1_5.avi ] && ls -l recent/127.0.0.1/03-0_1_5.avi | lookup '^.*localmedia/0_1_5[.]avi$'
+  [ -L recent/127.0.0.1/02-0_1_6.avi ] && ls -l recent/127.0.0.1/02-0_1_6.avi | lookup '^.*localmedia/0_1_6[.]avi$'
+  [ -L recent/127.0.0.1/01-0_1_3.avi ] && ls -l recent/127.0.0.1/01-0_1_3.avi | lookup '^.*localmedia/0_1_3[.]avi$'
 }
 
 it_uses_configurable_count() {
@@ -71,12 +137,12 @@ it_uses_configurable_count() {
 
   xupnpd &
   
-  http stream/0_1_1.avi
-  http stream/0_1_2.avi
-  http stream/0_1_3.avi
+  http stream/0_1_1.avi | lookup 'HTTP/1.1 200 OK'
+  http stream/0_1_2.avi | lookup 'HTTP/1.1 200 OK'
+  http stream/0_1_3.avi | lookup 'HTTP/1.1 200 OK'
   [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+  [ -L recent/127.0.0.1/02-0_1_2.avi ] && ls -l recent/127.0.0.1/02-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/01-0_1_3.avi ] && ls -l recent/127.0.0.1/01-0_1_3.avi | lookup '^.*localmedia/0_1_3[.]avi$'
 }
 
 it_uses_configurable_path_with_optional_terminal_slash() {
@@ -88,9 +154,43 @@ it_uses_configurable_path_with_optional_terminal_slash() {
   
   xupnpd &
   
-  http stream/0_1_2.avi
-  [ -L custom_recent_dir/127.0.0.1/01-0_1_1.avi ]
-  [ -L custom_recent_dir/127.0.0.1/02-0_1_2.avi ]
+  http stream/0_1_2.avi | lookup 'HTTP/1.1 200 OK'
+  [ -L custom_recent_dir/127.0.0.1/02-0_1_1.avi ] && ls -l custom_recent_dir/127.0.0.1/02-0_1_1.avi | lookup '^.*localmedia/0_1_1[.]avi$'
+  [ -L custom_recent_dir/127.0.0.1/01-0_1_2.avi ] && ls -l custom_recent_dir/127.0.0.1/01-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+}
+
+config_payload() {
+  cat <<BODY
+vk_private_workaround=true
+vk_video_count=100
+youtube_fmt=37
+youtube_region=*
+youtube_video_count=100
+vimeo_fmt=hd
+vimeo_video_count=100
+ivi_fmt=MP4-hi
+ivi_video_count=100
+ag_fmt=400p
+gametrailers_video_count=100
+name=UPnP-IPTV
+uuid=60bd2fb3-dabe-cb14-c766-0e319b54c29a
+default_mime_type=mpeg
+ssdp_interface=lo
+ssdp_notify_interval=15
+ssdp_max_age=1800
+http_port=4044
+user_agent=Mozilla%2F5.0
+http_timeout=30
+mcast_interface=eth1
+proxy=2
+dlna_notify=true
+dlna_subscribe_ttl=1800
+group=true
+sort_files=true
+feeds_update_interval=0
+playlists_update_interval=0
+drive=
+BODY
 }
 
 it_uses_ui_entered_path() {
@@ -103,48 +203,17 @@ it_uses_ui_entered_path() {
   
   xupnpd &
   
-  http stream/0_1_1.avi
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_1.avi ]
+  http stream/0_1_1.avi | lookup 'HTTP/1.1 200 OK'
+  [ -L recent/127.0.0.1/02-0_1_2.avi ] && ls -l recent/127.0.0.1/02-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/01-0_1_1.avi ] && ls -l recent/127.0.0.1/01-0_1_1.avi | lookup '^.*localmedia/0_1_1[.]avi$'
   [ -z "$(ls -A custom_recent_dir)" ]
 
-  cat <<BODY | tr '\n' '&' | http ui/apply --data-binary '@-'
-vk_private_workaround=true
-vk_video_count=100
-youtube_fmt=37
-youtube_region=*
-youtube_video_count=100
-vimeo_fmt=hd
-vimeo_video_count=100
-ivi_fmt=MP4-hi
-ivi_video_count=100
-ag_fmt=400p
-gametrailers_video_count=100
-recent_path=.%2Fcustom_recent_dir%2F
-name=UPnP-IPTV
-uuid=60bd2fb3-dabe-cb14-c766-0e319b54c29a
-default_mime_type=mpeg
-ssdp_interface=lo
-ssdp_notify_interval=15
-ssdp_max_age=1800
-http_port=4044
-user_agent=Mozilla%2F5.0
-http_timeout=30
-mcast_interface=eth1
-proxy=2
-dlna_notify=true
-dlna_subscribe_ttl=1800
-group=true
-sort_files=true
-feeds_update_interval=0
-playlists_update_interval=0
-drive=
-BODY
+  ( config_payload ; echo 'recent_path=.%2Fcustom_recent_dir%2F/' ) | tr '\n' '&' | http ui/apply --data-binary '@-'
 
-  http stream/0_1_3.avi
-  [ -L custom_recent_dir/127.0.0.1/01-0_1_2.avi ]
-  [ -L custom_recent_dir/127.0.0.1/02-0_1_1.avi ]
-  [ -L custom_recent_dir/127.0.0.1/03-0_1_3.avi ]
+  http stream/0_1_3.avi | lookup 'HTTP/1.1 200 OK'
+  [ -L custom_recent_dir/127.0.0.1/03-0_1_2.avi ] && ls -l custom_recent_dir/127.0.0.1/03-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L custom_recent_dir/127.0.0.1/02-0_1_1.avi ] && ls -l custom_recent_dir/127.0.0.1/02-0_1_1.avi | lookup '^.*localmedia/0_1_1[.]avi$'
+  [ -L custom_recent_dir/127.0.0.1/01-0_1_3.avi ] && ls -l custom_recent_dir/127.0.0.1/01-0_1_3.avi | lookup '^.*localmedia/0_1_3[.]avi$'
   [ ! -e recent ]
 }
 
@@ -155,86 +224,44 @@ it_uses_ui_entered_count() {
   
   xupnpd &
   
-  http stream/0_1_1.avi
-  http stream/0_1_2.avi
-  http stream/0_1_3.avi
+  http stream/0_1_1.avi | lookup 'HTTP/1.1 200 OK'
+  http stream/0_1_2.avi | lookup 'HTTP/1.1 200 OK'
+  http stream/0_1_3.avi | lookup 'HTTP/1.1 200 OK'
   [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+  [ -L recent/127.0.0.1/02-0_1_2.avi ] && ls -l recent/127.0.0.1/02-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/01-0_1_3.avi ] && ls -l recent/127.0.0.1/01-0_1_3.avi | lookup '^.*localmedia/0_1_3[.]avi$'
 
-  cat <<BODY | tr '\n' '&' | http ui/apply --data-binary '@-'
-vk_private_workaround=true
-vk_video_count=100
-youtube_fmt=37
-youtube_region=*
-youtube_video_count=100
-vimeo_fmt=hd
-vimeo_video_count=100
-ivi_fmt=MP4-hi
-ivi_video_count=100
-ag_fmt=400p
-gametrailers_video_count=100
-recent_count=3
-name=UPnP-IPTV
-uuid=60bd2fb3-dabe-cb14-c766-0e319b54c29a
-default_mime_type=mpeg
-ssdp_interface=lo
-ssdp_notify_interval=15
-ssdp_max_age=1800
-http_port=4044
-user_agent=Mozilla%2F5.0
-http_timeout=30
-mcast_interface=eth1
-proxy=2
-dlna_notify=true
-dlna_subscribe_ttl=1800
-group=true
-sort_files=true
-feeds_update_interval=0
-playlists_update_interval=0
-drive=
-BODY
+  ( config_payload ; echo 'recent_count=3' ) | tr '\n' '&' | http ui/apply --data-binary '@-'
 
-  http stream/0_1_3.avi
+  http stream/0_1_3.avi | lookup 'HTTP/1.1 200 OK'
   [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_3.avi ]
+  [ -L recent/127.0.0.1/02-0_1_2.avi ] && ls -l recent/127.0.0.1/02-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/01-0_1_3.avi ] && ls -l recent/127.0.0.1/01-0_1_3.avi | lookup '^.*localmedia/0_1_3[.]avi$'
 
-  http stream/0_1_4.avi
+  http stream/0_1_4.avi | lookup 'HTTP/1.1 200 OK'
   [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_3.avi ]
-  [ -L recent/127.0.0.1/03-0_1_4.avi ]
+  [ -L recent/127.0.0.1/03-0_1_2.avi ] && ls -l recent/127.0.0.1/03-0_1_2.avi | lookup '^.*localmedia/0_1_2[.]avi$'
+  [ -L recent/127.0.0.1/02-0_1_3.avi ] && ls -l recent/127.0.0.1/02-0_1_3.avi | lookup '^.*localmedia/0_1_3[.]avi$'
+  [ -L recent/127.0.0.1/01-0_1_4.avi ] && ls -l recent/127.0.0.1/01-0_1_4.avi | lookup '^.*localmedia/0_1_4[.]avi$'
 }
 
 it_handles_shell_metachars_correctly() {
   sed -i -re "/^cfg[.]recent_count\s*=\s*/ s|[0-9]+|2|" xupnpd.lua
-  for SPECIAL in "'" '"' '`' '$' '&' '|' ';' ':' '\\' '*' '!' '+' '#' '(' ')' '{' '}' '[' ']' '<' '>'; do
+  for SPECIAL in "'" '"' '`' '$' '&' '|' ';' ':' '\' '*' '!' '+' '#' '(' ')' '{' '}' '[' ']' '<' '>'; do
     seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t touch
     
-    pgrep xupnpd || xupnpd &
+    xupnpd &
     
     for i in $(seq 1 3); do
-      http "stream/0_1_$i.avi"
+      http "stream/0_1_$i.avi" | lookup 'HTTP/1.1 200 OK'
     done
     
-    [ ! -e "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ] && [ ! -L "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ]
-    [ -L "recent/127.0.0.1/01-0${SPECIAL}1_2.avi" ]
-    [ -L "recent/127.0.0.1/02-0${SPECIAL}1_3.avi" ]
+    [ ! -e "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ] && [ ! -L "recent/127.0.0.1/0[0-9]-0${SPECIAL}1_1.avi" ] # lookup -F '...' has trouble with backslash
+    [ -L "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" ] && ls -l "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" | grep -F "$(pwd)/localmedia/0${SPECIAL}1_2.avi"
+    [ -L "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" ] && ls -l "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" | grep -F "$(pwd)/localmedia/0${SPECIAL}1_3.avi"
     
     seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t rm -f
+    rm -vf "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" "recent/127.0.0.1/02-0${SPECIAL}1_2.avi"
+    kill $!
   done
-}
-
-it_updates_item_position_when_played_again() {
-  it_preserves_5_symlinks_by_default
-
-  http stream/0_2_2.avi
-
-  [ ! -e recent/127.0.0.1/0[0-9]-0_1_1.avi ] && [ ! -L recent/127.0.0.1/0[0-9]-0_1_1.avi ]
-  [ -L recent/127.0.0.1/01-0_1_2.avi ]
-  [ -L recent/127.0.0.1/02-0_1_4.avi ]
-  [ -L recent/127.0.0.1/03-0_1_5.avi ]
-  [ -L recent/127.0.0.1/04-0_1_6.avi ]
-  [ -L recent/127.0.0.1/05-0_1_3.avi ]
 }

--- a/test/plugins/recent.lua-test.sh
+++ b/test/plugins/recent.lua-test.sh
@@ -247,8 +247,8 @@ it_uses_ui_entered_count() {
 
 it_handles_shell_metachars_correctly() {
   sed -i -re "/^cfg[.]recent_count\s*=\s*/ s|[0-9]+|2|" xupnpd.lua
-  for SPECIAL in "'" '"' '`' '$' '&' '|' ';' ':' '\' '*' '!' '+' '#' '(' ')' '{' '}' '[' ']' '<' '>'; do
-    seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t touch
+  for SPECIAL in ' ' "'" '"' '`' '$' '&' '|' ';' ':' '\' '*' '!' '+' $'\n' $'\r' '#' '(' ')' '{' '}' '[' ']' '<' '>'; do
+    touch "localmedia/0${SPECIAL}1_1.avi" "localmedia/0${SPECIAL}1_2.avi" "localmedia/0${SPECIAL}1_3.avi"
     
     xupnpd &
     
@@ -260,7 +260,7 @@ it_handles_shell_metachars_correctly() {
     [ -L "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" ] && ls -l "recent/127.0.0.1/02-0${SPECIAL}1_2.avi" | grep -F "$(pwd)/localmedia/0${SPECIAL}1_2.avi"
     [ -L "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" ] && ls -l "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" | grep -F "$(pwd)/localmedia/0${SPECIAL}1_3.avi"
     
-    seq -f "localmedia/0${SPECIAL}1_%1.0f.avi" 1 3 | tr '\n' '\0' | xargs -0t rm -f
+    rm -f "localmedia/0${SPECIAL}1_1.avi" "localmedia/0${SPECIAL}1_2.avi" "localmedia/0${SPECIAL}1_3.avi"
     rm -vf "recent/127.0.0.1/01-0${SPECIAL}1_3.avi" "recent/127.0.0.1/02-0${SPECIAL}1_2.avi"
     kill $!
   done

--- a/test/plugins/recent.lua-test.sh
+++ b/test/plugins/recent.lua-test.sh
@@ -26,7 +26,7 @@ lookup() {	# [-F] [-A n] regex; like grep, but prints first match on success, ev
     REGEX == 0 && index($0, PATT) {found=1;lines=$0;if(AFTER==0)exit;next}
     lines {lines=lines""RS""$0;if(found&&--AFTER==0)exit;next}
     {lines=$0}
-    END {printf(lines);exit(1-found)}
+    END {print(lines);exit(1-found)}
   '
 }
 


### PR DESCRIPTION
It creates per IP address directory with symlinks to played media. This directory is available as automatically created 'Recent' playlist item, so far refreshed only when client is restarted (tested with VLC only). Test results from https://cloud.drone.io/samunders-core/xupnpd/28/1/2:
```
cd ../test; PLATFORM=x86 roundup plugins/*-test.sh	# https://github.com/samunders-core/roundup/tree/function_as_test_plan
profiles.lua
  it_loads_plugin_at_startup:                      [PASS]
  it_changes_profile_per_user_agent:               [PASS]
  it_uses_configurable_path:                       [PASS]
  it_uses_ui_entered_path:                         [PASS]
recent.lua
  it_loads_plugin_at_startup:                      [PASS]
  it_forces_sort_files:                            [PASS]
  it_symlinks_media_most_recent_first:             [PASS]
  it_preserves_5_symlinks_by_default:              [PASS]
  it_updates_item_position_when_played_again:      [PASS]
  it_uses_configurable_count:                      [PASS]
  it_retains_unique_path_components:               [PASS]
  it_uses_configurable_path_with_optional_terminal_slash: [PASS]
  it_uses_ui_entered_path:                         [PASS]
  it_uses_ui_entered_count:                        [PASS]
  it_handles_shell_metachars_correctly:            [PASS]
=========================================================
Tests:   15 | Passed:  15 | Failed:   0
```
BR, sam_